### PR TITLE
Move dash into bracket

### DIFF
--- a/blogpost_20201007.md
+++ b/blogpost_20201007.md
@@ -7,7 +7,7 @@ Da wir Menschen die ganze Zeit schlechte Luft ausatmen, müssen wir nur messen w
 Zum Messen gibt es nun entweder den Sensor BME680, welcher Luftdruck, Luftfeuchte, Temperatur und VOC misst oder aber den MH-Z19, welcher nur CO2 misst. Beim Chinesen des Vertrauens ist der BME680 um ein paar Euro zu bekommen, der MH-Z19 so um die 20 €. Ein paar Wochen Lieferzeit gibt's dazu! Wer weniger Geduld hat, der wird natürlich auch in deutschen Shops schnell fündig.
 
 
-Für den MH-Z19 und einen ESP32 habe ich in meinem Repo in der Datei main_tempsensor_esp32.py den (Micropython)-Code hinzugefügt.
+Für den MH-Z19 und einen ESP32 habe ich in meinem Repo in der Datei main_tempsensor_esp32.py den (Micropython-)Code hinzugefügt.
 
 Ich lasse CO2 somit jede Minute messen, lade es in eine Grafana Datenbank hoch und habe noch dazu einen Alarm, der mir meldet, sobald die Luft in meinem Büro schlecht wird.
 


### PR DESCRIPTION
I think the dash should be inside of the bracket. Otherwise it would stand for it's own when "not reading" the "Micropython"...